### PR TITLE
feat: add --since, defaulted to 2 years ago

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,21 @@ npx tidelift-me-up
 ✅ ghi-jkl is already lifted for $50.0/mo.
 ```
 
-If you are logged into npm, your npm username will be what's used.
-You can specify a username with `--username`:
+> Tip: add `| grep yet` to filter to only packages that are not yet lifted.
+>
+> ```shell
+> npx tidelift-me-up | grep yet
+> ```
+
+### Options
+
+- `--since` _(default: 2 years ago)_: A date that packages need to have been updated since to be considered
+  - This will be provided as a string to the `Date` constructor
+- `--username` _(default: result of `npm whoami`)_: The npm username to search for packages maintained by
+  - The search is done by [`npm-user-packages`](https://github.com/kevva/npm-user-packages), which fetches from [npm.io](https://npm.io)
 
 ```shell
-npx tidelift-me-up --username your-username
+npx tidelift-me-up --since 2020 --username your-username
 ```
 
 ## Development

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/src/getPackageEstimates.test.ts
+++ b/src/getPackageEstimates.test.ts
@@ -11,12 +11,12 @@ describe("getPackageEstimates", () => {
 		mockFetch.mockResolvedValue({
 			json: () => [
 				{
-					estimated_money: "12.34",
+					estimated_money: 12.34,
 					lifted: false,
 					name: "abc",
 				},
 				{
-					estimated_money: "56.78",
+					estimated_money: 56.78,
 					lifted: true,
 					name: "def",
 				},
@@ -27,12 +27,12 @@ describe("getPackageEstimates", () => {
 
 		expect(result).toEqual([
 			{
-				estimatedMoney: "12.34",
+				estimatedMoney: 12.34,
 				lifted: false,
 				name: "abc",
 			},
 			{
-				estimatedMoney: "56.78",
+				estimatedMoney: 56.78,
 				lifted: true,
 				name: "def",
 			},

--- a/src/tideliftMeUp.test.ts
+++ b/src/tideliftMeUp.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { tideliftMeUp } from "./tideliftMeUp.js";
+
+const mockNpmUserPackages = vi.fn();
+
+vi.mock("npm-user-packages", () => ({
+	get default() {
+		return mockNpmUserPackages;
+	},
+}));
+
+const mockGetPackageEstimates = vi.fn();
+
+vi.mock("./getPackageEstimates.js", () => ({
+	get getPackageEstimates() {
+		return mockGetPackageEstimates;
+	},
+}));
+
+describe("tideliftMeUp", () => {
+	it("defaults since to two years ago when not provided", async () => {
+		const packageNameNew = "package-name-new";
+		const packageNameOld = "package-name-old";
+
+		mockNpmUserPackages.mockResolvedValue([
+			{ date: new Date(), name: packageNameNew },
+			{ name: new Date(Date.now() - 1000), packageNameOld },
+		]);
+
+		await tideliftMeUp({ username: "abc123" });
+
+		expect(mockGetPackageEstimates).toHaveBeenCalledWith([packageNameNew]);
+	});
+
+	it("filters to packages to since when provided", async () => {
+		const packageNameNew = "package-name-new";
+		const packageNameOld = "package-name-old";
+
+		mockNpmUserPackages.mockResolvedValue([
+			{ date: new Date(Date.now()), name: packageNameNew },
+			{ date: new Date(Date.now() - 10_000), name: packageNameOld },
+		]);
+
+		await tideliftMeUp({
+			since: new Date(Date.now() - 20_000),
+			username: "abc123",
+		});
+
+		expect(mockGetPackageEstimates).toHaveBeenCalledWith([
+			packageNameNew,
+			packageNameOld,
+		]);
+	});
+});

--- a/src/tideliftMeUp.ts
+++ b/src/tideliftMeUp.ts
@@ -3,13 +3,26 @@ import npmUserPackages from "npm-user-packages";
 import { getPackageEstimates } from "./getPackageEstimates.js";
 
 export interface TideliftMeUpSettings {
+	since?: Date | number | string;
 	username: string;
 }
 
-export async function tideliftMeUp({ username }: TideliftMeUpSettings) {
-	const userPackages = await npmUserPackages(username);
+export async function tideliftMeUp({
+	since = getTwoYearsAgo(),
+	username,
+}: TideliftMeUpSettings) {
+	const sinceDate = new Date(since);
+	const userPackages = (await npmUserPackages(username)).filter(
+		(userPackage) => new Date(userPackage.date) >= sinceDate
+	);
 
 	return await getPackageEstimates(
 		userPackages.map((userPackage) => userPackage.name)
 	);
+}
+
+function getTwoYearsAgo() {
+	const date = new Date();
+	date.setFullYear(date.getFullYear() - 2);
+	return date;
 }

--- a/src/tideliftMeUpCli.ts
+++ b/src/tideliftMeUpCli.ts
@@ -8,19 +8,20 @@ export async function tideliftMeUpCli(args: string[]) {
 	const { values } = parseArgs({
 		args,
 		options: {
+			since: { type: "string" },
 			username: { type: "string" },
 		},
 		tokens: true,
 	});
 
-	const { username = await getNpmWhoami() } = values;
+	const { since, username = await getNpmWhoami() } = values;
 	if (!username) {
 		throw new Error(
 			"Either log in to npm or provide a username with --username."
 		);
 	}
 
-	const packageEstimates = await tideliftMeUp({ username });
+	const packageEstimates = await tideliftMeUp({ since, username });
 
 	for (const packageEstimate of packageEstimates) {
 		const currency = new Intl.NumberFormat("en-US", {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 		clearMocks: true,
 		coverage: {
 			all: true,
-			exclude: ["lib", "src/cli.ts", "src/tideliftMeUp.ts"],
+			exclude: ["lib", "src/cli.ts"],
 			include: ["src"],
 			provider: "istanbul",
 			reporter: ["html", "lcov"],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tidelift-me-up/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/tidelift-me-up/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds and documents a `--since` option, with unit tests. It defaults to 2 years prior to `new Date()`.