### PR TITLE
feat: default username in Node API as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,37 @@ npx tidelift-me-up
 npx tidelift-me-up --ownership author --ownership publisher --since 2020 --username your-username
 ```
 
+## Node API
+
+This package also exports a `tideliftMeUp` function you can call to receive an array of results:
+
+```js
+import { tideliftMeUp } from "tidelift-me-up";
+
+await tideliftMeUp();
+/*
+[
+	{
+		estimatedMoney: 25,
+		lifted: false,
+		name: 'your-eligible-package'
+	}
+]
+*/
+```
+
+It takes in the same options as the CLI:
+
+```js
+import { tideliftMeUp } from "tidelift-me-up";
+
+await tideliftMeUp({
+	ownership: ["author", "publisher"],
+	since: new Date("2020"),
+	username: "your-username",
+});
+```
+
 ## Development
 
 See [`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md), then [`.github/DEVELOPMENT.md`](./.github/DEVELOPMENT.md).

--- a/src/createUserPackagesFilter.test.ts
+++ b/src/createUserPackagesFilter.test.ts
@@ -1,20 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import {
-	UserPackageData,
-	createUserPackagesFilter,
-} from "./createUserPackagesFilter.js";
+import { createUserPackagesFilter } from "./createUserPackagesFilter.js";
+import { createFakePackageData } from "./fakes.js";
 
 const username = "abc123";
-
-const createPackageData = (overrides?: Partial<UserPackageData>) =>
-	({
-		author: { name: "" },
-		date: new Date().toString(),
-		maintainers: [],
-		publisher: { email: "", username: "" },
-		...overrides,
-	} satisfies UserPackageData);
 
 describe("createUserPackagesFilter", () => {
 	it("filters a package when its date predates since", () => {
@@ -25,7 +14,7 @@ describe("createUserPackagesFilter", () => {
 		});
 
 		const actual = filter(
-			createPackageData({
+			createFakePackageData({
 				author: { name: "", username },
 				date: new Date(Date.now() - 20_000).toString(),
 			})
@@ -42,7 +31,7 @@ describe("createUserPackagesFilter", () => {
 		});
 
 		const actual = filter(
-			createPackageData({
+			createFakePackageData({
 				author: { name: "", username },
 				date: new Date(Date.now() - 10_000).toString(),
 			})
@@ -59,7 +48,7 @@ describe("createUserPackagesFilter", () => {
 		});
 
 		const actual = filter(
-			createPackageData({
+			createFakePackageData({
 				author: { name: "", username: "other" },
 			})
 		);
@@ -75,7 +64,7 @@ describe("createUserPackagesFilter", () => {
 		});
 
 		const actual = filter(
-			createPackageData({
+			createFakePackageData({
 				author: { name: "", username },
 			})
 		);
@@ -91,7 +80,7 @@ describe("createUserPackagesFilter", () => {
 		});
 
 		const actual = filter(
-			createPackageData({
+			createFakePackageData({
 				maintainers: [{ email: "", username: "other" }],
 			})
 		);
@@ -107,7 +96,7 @@ describe("createUserPackagesFilter", () => {
 		});
 
 		const actual = filter(
-			createPackageData({
+			createFakePackageData({
 				maintainers: [{ email: "", username }],
 			})
 		);
@@ -123,7 +112,7 @@ describe("createUserPackagesFilter", () => {
 		});
 
 		const actual = filter(
-			createPackageData({
+			createFakePackageData({
 				publisher: { email: "", username: "other" },
 			})
 		);
@@ -139,7 +128,7 @@ describe("createUserPackagesFilter", () => {
 		});
 
 		const actual = filter(
-			createPackageData({
+			createFakePackageData({
 				publisher: { email: "", username },
 			})
 		);

--- a/src/fakes.ts
+++ b/src/fakes.ts
@@ -1,0 +1,10 @@
+import { UserPackageData } from "./createUserPackagesFilter.js";
+
+export const createFakePackageData = (overrides?: Partial<UserPackageData>) =>
+	({
+		author: { name: "" },
+		date: new Date().toString(),
+		maintainers: [],
+		publisher: { email: "", username: "" },
+		...overrides,
+	} satisfies UserPackageData);

--- a/src/getNpmWhoami.ts
+++ b/src/getNpmWhoami.ts
@@ -3,7 +3,7 @@ import npmWhoami from "npm-whoami";
 
 export async function getNpmWhoami() {
 	try {
-		return await util.promisify(npmWhoami)();
+		return await (util.promisify(npmWhoami)() as unknown as Promise<string>);
 	} catch {
 		return undefined;
 	}

--- a/src/getPackageEstimates.ts
+++ b/src/getPackageEstimates.ts
@@ -1,14 +1,10 @@
+import { PackageEstimate } from "./types.js";
+
 interface PackageEstimateData {
 	estimated_money: string;
 	lifted: boolean;
 	name: string;
 	platform: "npm";
-}
-
-export interface PackageEstimate {
-	estimatedMoney: number;
-	lifted: boolean;
-	name: string;
 }
 
 export async function getPackageEstimates(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./tideliftMeUp.js";
 export * from "./tideliftMeUpCli.js";
+export * from "./types.js";

--- a/src/tideliftMeUp.test.ts
+++ b/src/tideliftMeUp.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakePackageData } from "./fakes.js";
+import { tideliftMeUp } from "./tideliftMeUp.js";
+
+const mockNpmUserPackages = vi
+	.fn()
+	.mockResolvedValue([createFakePackageData()]);
+
+vi.mock("npm-user-packages", () => ({
+	get default() {
+		return mockNpmUserPackages;
+	},
+}));
+
+const mockGetNpmWhoami = vi.fn();
+
+vi.mock("./getNpmWhoami.js", () => ({
+	get getNpmWhoami() {
+		return mockGetNpmWhoami;
+	},
+}));
+
+vi.mock("./getPackageEstimates.js");
+
+describe("tideliftMeUp", () => {
+	it("throws an error when --username isn't provided and getNpmWhoami returns undefined", async () => {
+		mockGetNpmWhoami.mockResolvedValue(undefined);
+
+		await expect(() => tideliftMeUp()).rejects.toEqual(
+			new Error("Either log in to npm or provide a `username`.")
+		);
+	});
+
+	it("calls npmUserPackages with the npm name when the user is logged in", async () => {
+		const username = "abc123";
+
+		mockNpmUserPackages;
+		mockGetNpmWhoami.mockResolvedValue(username);
+
+		await tideliftMeUp();
+
+		expect(mockNpmUserPackages).toHaveBeenCalledWith(username);
+	});
+
+	it("calls npmUserPackages with the provided username when it exists", async () => {
+		const username = "abc123";
+
+		mockNpmUserPackages.mockResolvedValue([createFakePackageData()]);
+		mockGetNpmWhoami.mockRejectedValue(new Error("Should not be called."));
+
+		await tideliftMeUp({ username });
+
+		expect(mockNpmUserPackages).toHaveBeenCalledWith(username);
+	});
+});

--- a/src/tideliftMeUp.ts
+++ b/src/tideliftMeUp.ts
@@ -1,20 +1,26 @@
 import npmUserPackages from "npm-user-packages";
 
 import { createUserPackagesFilter } from "./createUserPackagesFilter.js";
+import { getNpmWhoami } from "./getNpmWhoami.js";
 import { getPackageEstimates } from "./getPackageEstimates.js";
 import { PackageOwnershipForm } from "./packageOwnershipForms.js";
 
 export interface TideliftMeUpSettings {
 	ownership?: PackageOwnershipForm[];
 	since?: Date | number | string;
-	username: string;
+	username?: string;
 }
 
 export async function tideliftMeUp({
 	ownership = ["author", "publisher"],
 	since = getTwoYearsAgo(),
 	username,
-}: TideliftMeUpSettings) {
+}: TideliftMeUpSettings = {}) {
+	username ??= await getNpmWhoami();
+	if (!username) {
+		throw new Error("Either log in to npm or provide a `username`.");
+	}
+
 	const userPackages = (await npmUserPackages(username)).filter(
 		createUserPackagesFilter({ ownership, since: new Date(since), username })
 	);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+export interface PackageEstimate {
+	estimatedMoney: number;
+	lifted: boolean;
+	name: string;
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #14; also fixes #11
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tidelift-me-up/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/tidelift-me-up/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds similar `?? = await getNpmWhoami()` logic to `tideliftMeUp` as already exists in `tideliftMeUpCli`. Also documents it in the README while I'm here.