### PR TITLE
feat: add --reporter option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ npx tidelift-me-up
 ### Options
 
 - `--ownership` _(default: `["author", "publisher"]`)_: If provided, any filters user packages must match one of based on username: `"author"`, `"maintainer"`, and/or `"publisher"`
+- `--reporter` _(default: `"text"`)_: Either `"json"` to output a raw JSON string, or `"text"` for human-readable output
 - `--since` _(default: 2 years ago)_: A date that packages need to have been updated since to be considered
   - This will be provided as a string to the `Date` constructor
 - `--username` _(default: result of `npm whoami`)_: The npm username to search for packages maintained by
   - The search is done by [`npm-user-packages`](https://github.com/kevva/npm-user-packages), which fetches from [npm.io](https://npm.io)
 
 ```shell
-npx tidelift-me-up --ownership author --ownership publisher --since 2020 --username your-username
+npx tidelift-me-up --ownership author --ownership publisher --reporter json --since 2020 --username your-username
 ```
 
 ## Node API
@@ -78,7 +79,7 @@ await tideliftMeUp();
 */
 ```
 
-It takes in the same options as the CLI:
+It takes in the same options as the CLI, except for `reporter`:
 
 ```js
 import { tideliftMeUp } from "tidelift-me-up";

--- a/src/reporters/jsonReporter.test.ts
+++ b/src/reporters/jsonReporter.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { jsonReporter } from "./jsonReporter.js";
+
+describe("jsonReporter", () => {
+	it("directly logs from JSON.stringify", () => {
+		const logger = vi.spyOn(console, "log").mockImplementation(() => undefined);
+		const packageEstimates = [
+			{
+				estimatedMoney: 12.34,
+				lifted: false,
+				name: "abc123",
+			},
+		];
+
+		jsonReporter(packageEstimates);
+
+		expect(logger).toHaveBeenCalledWith(JSON.stringify(packageEstimates));
+	});
+});

--- a/src/reporters/jsonReporter.ts
+++ b/src/reporters/jsonReporter.ts
@@ -1,0 +1,5 @@
+import { PackageEstimate } from "../types.js";
+
+export function jsonReporter(packageEstimates: PackageEstimate[]) {
+	console.log(JSON.stringify(packageEstimates));
+}

--- a/src/reporters/textReporter.test.ts
+++ b/src/reporters/textReporter.test.ts
@@ -1,0 +1,44 @@
+import chalk from "chalk";
+import { describe, expect, it, vi } from "vitest";
+
+import { textReporter } from "./textReporter.js";
+
+describe("textReporter", () => {
+	it("logs a package as already lifted when it is", () => {
+		const logger = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		textReporter([
+			{
+				estimatedMoney: 12.34,
+				lifted: true,
+				name: "abc123",
+			},
+		]);
+
+		expect(logger).toHaveBeenCalledWith(
+			chalk.gray(`✅ abc123 is already lifted for $12.34/mo.`)
+		);
+	});
+
+	it("logs a package as liftable when it is not yet lifted", () => {
+		const logger = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		textReporter([
+			{
+				estimatedMoney: 12.34,
+				lifted: false,
+				name: "abc123",
+			},
+		]);
+
+		expect(logger).toHaveBeenCalledWith(
+			[
+				chalk.cyan(`👉 `),
+				chalk.cyanBright("abc123"),
+				` is not yet lifted, but is estimated for `,
+				chalk.cyanBright(`$12.34/mo`),
+				`.`,
+			].join("")
+		);
+	});
+});

--- a/src/reporters/textReporter.ts
+++ b/src/reporters/textReporter.ts
@@ -1,0 +1,30 @@
+import chalk from "chalk";
+
+import { PackageEstimate } from "../types.js";
+
+export function textReporter(packageEstimates: PackageEstimate[]) {
+	for (const packageEstimate of packageEstimates) {
+		const currency = new Intl.NumberFormat("en-US", {
+			currency: "USD",
+			style: "currency",
+		}).format(packageEstimate.estimatedMoney);
+
+		if (packageEstimate.lifted) {
+			console.log(
+				chalk.gray(
+					`✅ ${packageEstimate.name} is already lifted for ${currency}/mo.`
+				)
+			);
+		} else {
+			console.log(
+				[
+					chalk.cyan(`👉 `),
+					chalk.cyanBright(packageEstimate.name),
+					` is not yet lifted, but is estimated for `,
+					chalk.cyanBright(`${currency}/mo`),
+					`.`,
+				].join("")
+			);
+		}
+	}
+}

--- a/src/tideliftMeUpCli.test.ts
+++ b/src/tideliftMeUpCli.test.ts
@@ -1,4 +1,3 @@
-import chalk from "chalk";
 import { describe, expect, it, vi } from "vitest";
 
 import { tideliftMeUpCli } from "./tideliftMeUpCli.js";

--- a/src/tideliftMeUpCli.test.ts
+++ b/src/tideliftMeUpCli.test.ts
@@ -20,6 +20,17 @@ vi.mock("./tideliftMeUp.js", () => ({
 }));
 
 describe("tideliftMeUpCli", () => {
+	it("throws an error when --reporter is provided and not json or text", async () => {
+		mockGetNpmWhoami.mockResolvedValue(undefined);
+
+		const reporter = "invalid";
+		await expect(() =>
+			tideliftMeUpCli(["--reporter", reporter])
+		).rejects.toEqual(
+			new Error(`--reporter must be "json" or "text", not ${reporter}.`)
+		);
+	});
+
 	it("throws an error when --username isn't provided and getNpmWhoami returns undefined", async () => {
 		mockGetNpmWhoami.mockResolvedValue(undefined);
 
@@ -52,47 +63,5 @@ describe("tideliftMeUpCli", () => {
 		expect(mockTideliftMeUp).toHaveBeenCalledWith({
 			username,
 		});
-	});
-
-	it("logs a package as already lifted when it is", async () => {
-		const logger = vi.spyOn(console, "log").mockImplementation(() => undefined);
-
-		mockTideliftMeUp.mockResolvedValue([
-			{
-				estimatedMoney: "12.34",
-				lifted: true,
-				name: "abc123",
-			},
-		]);
-
-		await tideliftMeUpCli(["--username", "abc123"]);
-
-		expect(logger).toHaveBeenCalledWith(
-			chalk.gray(`✅ abc123 is already lifted for $12.34/mo.`)
-		);
-	});
-
-	it("logs a package as liftable when it is not yet lifted", async () => {
-		const logger = vi.spyOn(console, "log").mockImplementation(() => undefined);
-
-		mockTideliftMeUp.mockResolvedValue([
-			{
-				estimatedMoney: "12.34",
-				lifted: false,
-				name: "abc123",
-			},
-		]);
-
-		await tideliftMeUpCli(["--username", "abc123"]);
-
-		expect(logger).toHaveBeenCalledWith(
-			[
-				chalk.cyan(`👉 `),
-				chalk.cyanBright("abc123"),
-				` is not yet lifted, but is estimated for `,
-				chalk.cyanBright(`$12.34/mo`),
-				`.`,
-			].join("")
-		);
 	});
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tidelift-me-up/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/tidelift-me-up/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `--reporter` option that so far can be `"json"` or `"text"`. If folks want something else, or custom reporters, I suppose they can request that in later.