### PR TITLE
feat: allow comma-separated owners

### DIFF
--- a/src/assertValidOwnership.ts
+++ b/src/assertValidOwnership.ts
@@ -3,13 +3,13 @@ import { PackageOwnership } from "./types.js";
 const packageOwnerships = ["author", "maintainer", "publisher"];
 
 export function assertValidOwnership(
-	ownerships: string[] | undefined,
-): asserts ownerships is PackageOwnership[] | undefined {
-	if (ownerships) {
-		for (const ownership of ownerships) {
-			if (!packageOwnerships.includes(ownership)) {
+	ownership: string[] | undefined,
+): asserts ownership is PackageOwnership[] | undefined {
+	if (ownership) {
+		for (const value of ownership) {
+			if (!packageOwnerships.includes(value)) {
 				throw new Error(
-					`Unknown --ownership: ${ownership} (must be one of: ${packageOwnerships.join(
+					`Unknown --ownership: ${value} (must be one of: ${packageOwnerships.join(
 						", ",
 					)})`,
 				);

--- a/src/parseOwnership.test.ts
+++ b/src/parseOwnership.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, test } from "vitest";
+
+import { parseOwnership } from "./parseOwnership.js";
+
+describe("parseOwnership", () => {
+	test.each([
+		[undefined, undefined],
+		[[], []],
+		[["abc"], ["abc"]],
+		[
+			["abc,def", "ghi"],
+			["abc", "def", "ghi"],
+		],
+		[
+			[" abc , def ", "ghi"],
+			["abc", "def", "ghi"],
+		],
+	])("%j", (input, expected) => {
+		expect(parseOwnership(input)).toEqual(expected);
+	});
+});

--- a/src/parseOwnership.test.ts
+++ b/src/parseOwnership.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { parseOwnership } from "./parseOwnership.js";
 

--- a/src/parseOwnership.ts
+++ b/src/parseOwnership.ts
@@ -1,0 +1,5 @@
+export function parseOwnership(raw: string[] | undefined) {
+	return raw
+		?.flatMap((raw) => raw.split(","))
+		.map((ownership) => ownership.trim());
+}

--- a/src/tideliftMeUpCli.ts
+++ b/src/tideliftMeUpCli.ts
@@ -2,6 +2,7 @@ import { parseArgs } from "node:util";
 
 import { assertValidOwnership } from "./assertValidOwnership.js";
 import { getNpmWhoami } from "./getNpmWhoami.js";
+import { parseOwnership } from "./parseOwnership.js";
 import { jsonReporter } from "./reporters/jsonReporter.js";
 import { textReporter } from "./reporters/textReporter.js";
 import { tideliftMeUp } from "./tideliftMeUp.js";
@@ -26,12 +27,9 @@ export async function tideliftMeUpCli(args: string[]) {
 		tokens: true,
 	});
 
-	const {
-		ownership,
-		reporter: reporterRaw,
-		since,
-		username: usernameRaw,
-	} = values;
+	const { reporter: reporterRaw, since, username: usernameRaw } = values;
+
+	const ownership = parseOwnership(values.ownership);
 
 	assertValidOwnership(ownership);
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tidelift-me-up/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/tidelift-me-up/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses a `.flatMap` as suggested in the issue so that folks can pass in ownership like `--ownership abc,def`.

Also renames `ownerships` in `assertValidOwnership` because it was confusing me, and is even more confusing with more references to "ownership" in this PR.

Thanks @StyleShit for suggesting the `.trim()`! 😄 

Co-authored-by: Evyatar Daud <evyatar.daud@gmail.com>