### PR TITLE
feat: added rudimentary -h/--help to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ npx tidelift-me-up
 
 ### Options
 
+- `-h`/`--help`: Print these options to the terminal
 - `--ownership` _(default: `["author", "publisher"]`)_: If provided, any filters user packages must match one of based on username: `"author"`, `"maintainer"`, and/or `"publisher"`
 - `--reporter` _(default: `"text"`)_: Either `"json"` to output a raw JSON string, or `"text"` for human-readable output
 - `--since` _(default: 2 years ago)_: A date that packages need to have been updated since to be considered
   - This will be provided as a string to the `Date` constructor
-- `--username` _(default: result of `npm whoami`)_: The npm username to search for packages maintained by
+- `--username` _(default: result of `npm whoami`)_: The npm username to search for packages owned by
   - The search is done by a network call to [https://registry.npmjs.org](https://https://registry.npmjs.org) (documented at [github.com/npm/registry](https://github.com/npm/registry))
 
 ```shell

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
-import { tideliftMeUpCli } from "../lib/tideliftMeUpCli.js";
+import { tideliftMeUpCli } from "../lib/cli/tideliftMeUpCli.js";
 
 await tideliftMeUpCli(process.argv.slice(2));

--- a/src/cli/argsOptions.ts
+++ b/src/cli/argsOptions.ts
@@ -1,0 +1,43 @@
+import { ParseArgsConfig } from "node:util";
+
+export type ParseArgsOptionsConfig = NonNullable<ParseArgsConfig["options"]>;
+
+export type ParseArgsOptionConfig = ParseArgsOptionsConfig[string];
+
+export interface DescribedParseArgsOptionConfig extends ParseArgsOptionConfig {
+	description: string;
+}
+
+export type DescribedParseArgsConfig = Record<
+	string,
+	DescribedParseArgsOptionConfig
+>;
+
+export const argsOptions = {
+	help: {
+		description: "Print this help text.",
+		short: "h",
+		type: "boolean",
+	},
+	ownership: {
+		description:
+			"(default: ['author', 'publisher']) Any filters user packages must match one of based on username: 'author', 'maintainer', and/or 'publisher'.",
+		multiple: true,
+		type: "string",
+	},
+	reporter: {
+		description:
+			"(default: 'text') Either 'json' to output a raw JSON string, or 'text' for human-readable output.",
+		type: "string",
+	},
+	since: {
+		description:
+			"(default: 2 years ago) A date that packages need to have been updated since to be considered.",
+		type: "string",
+	},
+	username: {
+		description:
+			"(default: result of npm whoami) The npm username to search for packages owned by.",
+		type: "string",
+	},
+} satisfies DescribedParseArgsConfig;

--- a/src/cli/logHelp.test.ts
+++ b/src/cli/logHelp.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 
 import { logHelp } from "./logHelp.js";
 

--- a/src/cli/logHelp.test.ts
+++ b/src/cli/logHelp.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, test, vi } from "vitest";
+
+import { logHelp } from "./logHelp.js";
+
+test("logHelp", () => {
+	const mockLog = vi.fn();
+
+	console.log = mockLog;
+
+	logHelp();
+
+	expect(mockLog.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "-h/--help Print this help text.
+		--ownership (default: ['author', 'publisher']) Any filters user packages must match one of based on username: 'author', 'maintainer', and/or 'publisher'.
+		--reporter (default: 'text') Either 'json' to output a raw JSON string, or 'text' for human-readable output.
+		--since (default: 2 years ago) A date that packages need to have been updated since to be considered.
+		--username (default: result of npm whoami) The npm username to search for packages owned by.",
+		  ],
+		]
+	`);
+});

--- a/src/cli/logHelp.ts
+++ b/src/cli/logHelp.ts
@@ -1,0 +1,20 @@
+import { argsOptions } from "./argsOptions.js";
+
+export function logHelp() {
+	console.log(
+		Object.entries(argsOptions)
+			.map(([longOption, optionConfig]) => {
+				let line = "";
+
+				if ("short" in optionConfig) {
+					line += `-${optionConfig.short}/`;
+				}
+
+				line += `--${longOption}`;
+				line += ` ${optionConfig.description}`;
+
+				return line;
+			})
+			.join("\n"),
+	);
+}

--- a/src/cli/tideliftMeUpCli.test.ts
+++ b/src/cli/tideliftMeUpCli.test.ts
@@ -4,7 +4,7 @@ import { tideliftMeUpCli } from "./tideliftMeUpCli.js";
 
 const mockGetNpmWhoami = vi.fn();
 
-vi.mock("./getNpmWhoami.js", () => ({
+vi.mock("../getNpmWhoami.js", () => ({
 	get getNpmWhoami() {
 		return mockGetNpmWhoami;
 	},
@@ -12,13 +12,29 @@ vi.mock("./getNpmWhoami.js", () => ({
 
 const mockTideliftMeUp = vi.fn();
 
-vi.mock("./tideliftMeUp.js", () => ({
+vi.mock("../tideliftMeUp.js", () => ({
 	get tideliftMeUp() {
 		return mockTideliftMeUp;
 	},
 }));
 
+const mockLogHelp = vi.fn();
+
+vi.mock("./logHelp.js", () => ({
+	get logHelp() {
+		return mockLogHelp;
+	},
+}));
+
 describe("tideliftMeUpCli", () => {
+	it("logs help when args include --help", async () => {
+		await tideliftMeUpCli(["--help"]);
+
+		expect(mockLogHelp).toHaveBeenCalled();
+		expect(mockGetNpmWhoami).not.toHaveBeenCalled();
+		expect(mockTideliftMeUp).not.toHaveBeenCalled();
+	});
+
 	it("throws an error when --reporter is provided and not json or text", async () => {
 		mockGetNpmWhoami.mockResolvedValue(undefined);
 
@@ -45,6 +61,7 @@ describe("tideliftMeUpCli", () => {
 
 		await tideliftMeUpCli(["--username", username]);
 
+		expect(mockLogHelp).not.toHaveBeenCalled();
 		expect(mockGetNpmWhoami).not.toHaveBeenCalled();
 		expect(mockTideliftMeUp).toHaveBeenCalledWith({
 			username,
@@ -54,6 +71,7 @@ describe("tideliftMeUpCli", () => {
 	it("logs packages for a username when --username is not provided and the user is logged in", async () => {
 		const username = "abc123";
 
+		expect(mockLogHelp).not.toHaveBeenCalled();
 		mockGetNpmWhoami.mockResolvedValue(username);
 		mockTideliftMeUp.mockResolvedValue([]);
 

--- a/src/cli/tideliftMeUpCli.ts
+++ b/src/cli/tideliftMeUpCli.ts
@@ -1,11 +1,13 @@
 import { parseArgs } from "node:util";
 
-import { assertValidOwnership } from "./assertValidOwnership.js";
-import { getNpmWhoami } from "./getNpmWhoami.js";
-import { parseOwnership } from "./parseOwnership.js";
-import { jsonReporter } from "./reporters/jsonReporter.js";
-import { textReporter } from "./reporters/textReporter.js";
-import { tideliftMeUp } from "./tideliftMeUp.js";
+import { assertValidOwnership } from "../assertValidOwnership.js";
+import { getNpmWhoami } from "../getNpmWhoami.js";
+import { parseOwnership } from "../parseOwnership.js";
+import { jsonReporter } from "../reporters/jsonReporter.js";
+import { textReporter } from "../reporters/textReporter.js";
+import { tideliftMeUp } from "../tideliftMeUp.js";
+import { argsOptions } from "./argsOptions.js";
+import { logHelp } from "./logHelp.js";
 
 const reporters = {
 	json: jsonReporter,
@@ -15,17 +17,14 @@ const reporters = {
 export async function tideliftMeUpCli(args: string[]) {
 	const { values } = parseArgs({
 		args,
-		options: {
-			ownership: {
-				multiple: true,
-				type: "string",
-			},
-			reporter: { type: "string" },
-			since: { type: "string" },
-			username: { type: "string" },
-		},
+		options: argsOptions,
 		tokens: true,
 	});
+
+	if (values.help) {
+		logHelp();
+		return;
+	}
 
 	const { reporter: reporterRaw, since, username: usernameRaw } = values;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./tideliftMeUp.js";
-export * from "./tideliftMeUpCli.js";
+export * from "./cli/tideliftMeUpCli.js";
 export * from "./types.js";


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #217
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tidelift-me-up/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/tidelift-me-up/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a very basic help text with `-h`/`--help`:

```plaintext
$ node ./bin/index.js --help
-h/--help Print this help text.
--ownership (default: ['author', 'publisher']) Any filters user packages must match one of based on username: 'author', 'maintainer', and/or 'publisher'.
--reporter (default: 'text') Either 'json' to output a raw JSON string, or 'text' for human-readable output.
--since (default: 2 years ago) A date that packages need to have been updated since to be considered.
--username (default: result of npm whoami) The npm username to search for packages owned by.
```

Obviously it'd be nicer to have colors, indentation, version logging, etc. But I'd love to find or make a generalized package for that. 