### PR TITLE
feat: added a --status filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ npx tidelift-me-up
 - `--reporter` _(default: `"text"`)_: Either `"json"` to output a raw JSON string, or `"text"` for human-readable output
 - `--since` _(default: 2 years ago)_: A date that packages need to have been updated since to be considered
   - This will be provided as a string to the `Date` constructor
+- `--status` _(default: `'all'`)_: If provided, a filter on package lifting status: `'all'`, `"available"`, or `"lifted"`
 - `--username` _(default: result of `npm whoami`)_: The npm username to search for packages owned by
   - The search is done by a network call to [https://registry.npmjs.org](https://https://registry.npmjs.org) (documented at [github.com/npm/registry](https://github.com/npm/registry))
 

--- a/src/cli/argsOptions.ts
+++ b/src/cli/argsOptions.ts
@@ -35,6 +35,11 @@ export const argsOptions = {
 			"(default: 2 years ago) A date that packages need to have been updated since to be considered.",
 		type: "string",
 	},
+	status: {
+		description:
+			"(default: 'all') If provided, a filter on package lifting status: 'all', 'available', or 'lifted'.",
+		type: "string",
+	},
 	username: {
 		description:
 			"(default: result of npm whoami) The npm username to search for packages owned by.",

--- a/src/cli/logHelp.test.ts
+++ b/src/cli/logHelp.test.ts
@@ -16,6 +16,7 @@ test("logHelp", () => {
 		--ownership (default: ['author', 'publisher']) Any filters user packages must match one of based on username: 'author', 'maintainer', and/or 'publisher'.
 		--reporter (default: 'text') Either 'json' to output a raw JSON string, or 'text' for human-readable output.
 		--since (default: 2 years ago) A date that packages need to have been updated since to be considered.
+		--status (default: 'all') If provided, a filter on package lifting status: 'all', 'available', or 'lifted'.
 		--username (default: result of npm whoami) The npm username to search for packages owned by.",
 		  ],
 		]

--- a/src/cli/tideliftMeUpCli.test.ts
+++ b/src/cli/tideliftMeUpCli.test.ts
@@ -46,6 +46,17 @@ describe("tideliftMeUpCli", () => {
 		);
 	});
 
+	it("throws an error when --status is provided and not all, available, or lifted", async () => {
+		mockGetNpmWhoami.mockResolvedValue(undefined);
+
+		const reporter = "invalid";
+		await expect(() => tideliftMeUpCli(["--status", reporter])).rejects.toEqual(
+			new Error(
+				`--status must be "all", "available", or "lifted", not ${reporter}.`,
+			),
+		);
+	});
+
 	it("throws an error when --username isn't provided and getNpmWhoami returns undefined", async () => {
 		mockGetNpmWhoami.mockResolvedValue(undefined);
 

--- a/src/cli/tideliftMeUpCli.ts
+++ b/src/cli/tideliftMeUpCli.ts
@@ -6,6 +6,7 @@ import { parseOwnership } from "../parseOwnership.js";
 import { jsonReporter } from "../reporters/jsonReporter.js";
 import { textReporter } from "../reporters/textReporter.js";
 import { tideliftMeUp } from "../tideliftMeUp.js";
+import { PackageStatus } from "../types.js";
 import { argsOptions } from "./argsOptions.js";
 import { logHelp } from "./logHelp.js";
 
@@ -26,7 +27,12 @@ export async function tideliftMeUpCli(args: string[]) {
 		return;
 	}
 
-	const { reporter: reporterRaw, since, username: usernameRaw } = values;
+	const {
+		reporter: reporterRaw,
+		since,
+		status,
+		username: usernameRaw,
+	} = values;
 
 	const ownership = parseOwnership(values.ownership);
 
@@ -37,6 +43,17 @@ export async function tideliftMeUpCli(args: string[]) {
 		throw new Error(`--reporter must be "json" or "text", not ${reporter}.`);
 	}
 
+	if (
+		status &&
+		status !== "all" &&
+		status !== "available" &&
+		status !== "lifted"
+	) {
+		throw new Error(
+			`--status must be "all", "available", or "lifted", not ${status}.`,
+		);
+	}
+
 	const username = usernameRaw ?? (await getNpmWhoami());
 	if (!username) {
 		throw new Error(
@@ -44,7 +61,12 @@ export async function tideliftMeUpCli(args: string[]) {
 		);
 	}
 
-	const packageEstimates = await tideliftMeUp({ ownership, since, username });
+	const packageEstimates = await tideliftMeUp({
+		ownership,
+		since,
+		status: status as PackageStatus,
+		username,
+	});
 
 	reporters[reporter](packageEstimates);
 }

--- a/src/createStatusFilter.test.ts
+++ b/src/createStatusFilter.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createStatusFilter } from "./createStatusFilter.js";
+
+const mockFetch = vi.fn();
+
+vi.stubGlobal("fetch", mockFetch);
+
+describe("createStatusFilter", () => {
+	describe.each([
+		["all", true, true],
+		["available", false, true],
+		["lifted", true, false],
+	] as const)("when status is %s", (status, lifted, notLifted) => {
+		it(`returns ${lifted} when lifted is true`, () => {
+			const filter = createStatusFilter(status);
+
+			const actual = filter({ estimatedMoney: 0, lifted: true, name: "" });
+
+			expect(actual).toBe(lifted);
+		});
+
+		it(`returns ${notLifted} when lifted is false`, () => {
+			const filter = createStatusFilter(status);
+
+			const actual = filter({ estimatedMoney: 0, lifted: false, name: "" });
+
+			expect(actual).toBe(notLifted);
+		});
+	});
+});

--- a/src/createStatusFilter.ts
+++ b/src/createStatusFilter.ts
@@ -1,0 +1,17 @@
+import { PackageEstimate } from "./getPackageEstimates.js";
+import { PackageStatus } from "./types.js";
+
+export type PackageFilter = (packageEstimate: PackageEstimate) => boolean;
+
+export function createStatusFilter(status: PackageStatus): PackageFilter {
+	switch (status) {
+		case "all":
+			return () => true;
+
+		case "available":
+			return (packageEstimate) => !packageEstimate.lifted;
+
+		case "lifted":
+			return (packageEstimate) => packageEstimate.lifted;
+	}
+}

--- a/src/getPackageEstimates.test.ts
+++ b/src/getPackageEstimates.test.ts
@@ -7,7 +7,7 @@ const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 describe("getPackageEstimates", () => {
-	it("maps estimates data", async () => {
+	it("maps estimated data", async () => {
 		mockFetch.mockResolvedValue({
 			json: () => [
 				{

--- a/src/getPackageEstimates.ts
+++ b/src/getPackageEstimates.ts
@@ -5,7 +5,15 @@ interface PackageEstimateData {
 	platform: "npm";
 }
 
-export async function getPackageEstimates(packageNames: string[]) {
+export interface PackageEstimate {
+	estimatedMoney: number;
+	lifted: boolean;
+	name: string;
+}
+
+export async function getPackageEstimates(
+	packageNames: string[],
+): Promise<PackageEstimate[]> {
 	const response = await fetch(
 		"https://tidelift.com/api/depci/estimate/bulk_estimates",
 		{

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,3 +8,5 @@ export interface EstimatedPackage {
 }
 
 export type PackageOwnership = "author" | "maintainer" | "publisher";
+
+export type PackageStatus = "all" | "available" | "lifted";


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #218
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tidelift-me-up/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/tidelift-me-up/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds `--status` which can be `"all"`, `"available"`, or `"lifted"`.