### PR TITLE
fix: don't include monetary estimates for lifted packages

### DIFF
--- a/src/createStatusFilter.test.ts
+++ b/src/createStatusFilter.test.ts
@@ -15,7 +15,7 @@ describe("createStatusFilter", () => {
 		it(`returns ${lifted} when lifted is true`, () => {
 			const filter = createStatusFilter(status);
 
-			const actual = filter({ estimatedMoney: 0, lifted: true, name: "" });
+			const actual = filter({ lifted: true, name: "" });
 
 			expect(actual).toBe(lifted);
 		});
@@ -23,7 +23,7 @@ describe("createStatusFilter", () => {
 		it(`returns ${notLifted} when lifted is false`, () => {
 			const filter = createStatusFilter(status);
 
-			const actual = filter({ estimatedMoney: 0, lifted: false, name: "" });
+			const actual = filter({ estimatedMoney: 10, lifted: false, name: "" });
 
 			expect(actual).toBe(notLifted);
 		});

--- a/src/getPackageEstimates.ts
+++ b/src/getPackageEstimates.ts
@@ -5,11 +5,20 @@ interface PackageEstimateData {
 	platform: "npm";
 }
 
-export interface PackageEstimate {
-	estimatedMoney: number;
-	lifted: boolean;
+export interface PackageEstimateBase {
 	name: string;
 }
+
+export interface PackageEstimateLifted extends PackageEstimateBase {
+	lifted: true;
+}
+
+export interface PackageEstimateNotLifted extends PackageEstimateBase {
+	estimatedMoney: number;
+	lifted: false;
+}
+
+export type PackageEstimate = PackageEstimateLifted | PackageEstimateNotLifted;
 
 export async function getPackageEstimates(
 	packageNames: string[],

--- a/src/reporters/textReporter.test.ts
+++ b/src/reporters/textReporter.test.ts
@@ -11,14 +11,13 @@ describe("textReporter", () => {
 		textReporter([
 			{
 				data: createFakePackageData(),
-				estimatedMoney: 12.34,
 				lifted: true,
 				name: "abc123",
 			},
 		]);
 
 		expect(logger).toHaveBeenCalledWith(
-			chalk.gray(`✅ abc123 is already lifted for $12.34/mo.`),
+			chalk.gray(`✅ abc123 is already lifted.`),
 		);
 	});
 

--- a/src/reporters/textReporter.ts
+++ b/src/reporters/textReporter.ts
@@ -3,28 +3,27 @@ import chalk from "chalk";
 import { EstimatedPackage } from "../types.js";
 
 export function textReporter(estimatedPackages: EstimatedPackage[]) {
-	for (const estimatedPackage of estimatedPackages) {
-		const currency = new Intl.NumberFormat("en-US", {
-			currency: "USD",
-			style: "currency",
-		}).format(estimatedPackage.estimatedMoney);
+	const formatter = new Intl.NumberFormat("en-US", {
+		currency: "USD",
+		style: "currency",
+	});
 
+	for (const estimatedPackage of estimatedPackages) {
 		if (estimatedPackage.lifted) {
-			console.log(
-				chalk.gray(
-					`✅ ${estimatedPackage.name} is already lifted for ${currency}/mo.`,
-				),
-			);
-		} else {
-			console.log(
-				[
-					chalk.cyan(`👉 `),
-					chalk.cyanBright(estimatedPackage.name),
-					` is not yet lifted, but is estimated for `,
-					chalk.cyanBright(`${currency}/mo`),
-					`.`,
-				].join(""),
-			);
+			console.log(chalk.gray(`✅ ${estimatedPackage.name} is already lifted.`));
+			continue;
 		}
+
+		const currency = formatter.format(estimatedPackage.estimatedMoney);
+
+		console.log(
+			[
+				chalk.cyan(`👉 `),
+				chalk.cyanBright(estimatedPackage.name),
+				` is not yet lifted, but is estimated for `,
+				chalk.cyanBright(`${currency}/mo`),
+				`.`,
+			].join(""),
+		);
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,22 @@
 import { PackageData } from "npm-username-to-packages";
 
-export interface EstimatedPackage {
+export interface EstimatedPackageBase {
 	data: PackageData;
-	estimatedMoney: number;
-	lifted: boolean;
 	name: string;
 }
+
+export interface EstimatedPackageLifted extends EstimatedPackageBase {
+	lifted: true;
+}
+
+export interface EstimatedPackageNotLifted extends EstimatedPackageBase {
+	estimatedMoney: number;
+	lifted: false;
+}
+
+export type EstimatedPackage =
+	| EstimatedPackageLifted
+	| EstimatedPackageNotLifted;
 
 export type PackageOwnership = "author" | "maintainer" | "publisher";
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #252
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tidelift-me-up/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/tidelift-me-up/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changes the types for packages to discriminated/tagged unions to represent that estimated money is only available on non-lifted ones.